### PR TITLE
Add X-content-type-options, refferer-policy, content-security-policy

### DIFF
--- a/quiz-game/src/hooks.server.ts
+++ b/quiz-game/src/hooks.server.ts
@@ -5,20 +5,5 @@ export const handle: Handle = async ({ event, resolve }) => {
     const response = await resolve(event);
 	response.headers.set('X-Content-Type-Options', 'nosniff');
     response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-    if (!dev && !response.headers.has('Content-Security-Policy')) {
-        response.headers.set(
-            'Content-Security-Policy',
-            "default-src 'self'; " +
-            "script-src 'self'; " +
-            "style-src 'self' 'unsafe-inline'; " +
-            "img-src 'self' data: https:; " +
-            "font-src 'self' data:; " +
-            "connect-src 'self'; " +
-            "frame-ancestors 'none'; " +
-            "base-uri 'self'; " +
-            "form-action 'self'"
-        );
-    }
-
 	return response;
 };

--- a/quiz-game/svelte.config.js
+++ b/quiz-game/svelte.config.js
@@ -3,11 +3,23 @@ import adapter from '@sveltejs/adapter-auto';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter()
+		adapter: adapter(),
+		csp: {
+			mode: 'auto',
+			directives: {
+				'default-src': ['self'],
+				'script-src': ['self'],
+				'style-src': ['self', 'unsafe-inline'],
+				'img-src': ['self', 'data:', 'https:'],
+				'font-src': ['self', 'data:'],
+				'connect-src': ['self'],
+				'frame-ancestors': ['none'],
+				'base-uri': ['self'],
+				'form-action': ['self']
+			}
+		}
 	}
+
 };
 
 export default config;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adds security response headers: X-Content-Type-Options and Referrer-Policy.
  * Enables a Content-Security-Policy (auto mode) to restrict framing, limit script/connect sources to same-origin, allow self/inline styles, and permit images/fonts from safe sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->