### PR TITLE
small hotfix to countdown

### DIFF
--- a/quiz-game/src/lib/server/gameSession.server.ts
+++ b/quiz-game/src/lib/server/gameSession.server.ts
@@ -91,7 +91,8 @@ export async function createGameSession(playerName: string) {
     const sessionId = crypto.randomUUID();
     const questionOrder = shuffleArray(QUESTIONS.map((q) => q.id));
     const choiceOrderMap = buildChoiceOrderMap();
-    const expiresAt = new Date(Date.now() + GAME_DURATION_MS).toISOString();
+    const GRACE_PERIOD_MS = 5000; // Account for 3s countdown + network lag
+    const expiresAt = new Date(Date.now() + GAME_DURATION_MS + GRACE_PERIOD_MS).toISOString();
 
     await db.execute({
         sql: `
@@ -106,7 +107,7 @@ export async function createGameSession(playerName: string) {
 
     return {
         sessionId,
-        timeLeftMs: GAME_DURATION_MS,
+        timeLeftMs: getTimeLeftMs(expiresAt),
         questionIndex: 0,
         score: 0,
         question: publicQuestionFromState(questionOrder[0], choiceOrderMap)

--- a/quiz-game/src/routes/play/+page.svelte
+++ b/quiz-game/src/routes/play/+page.svelte
@@ -58,11 +58,11 @@
 
 			if (count > 0) {
 				countdown = count;
-            } else if (count === 0) {
-                countdown = 'Go!';
-				if (!startPromise) {
+				if (count === 2 && !startPromise) {
                 	startPromise = startGame();
 				}
+            } else if (count === 0) {
+                countdown = 'Go!';
             } else {
                 clearInterval(countInterval!);
                 countInterval = null;
@@ -76,7 +76,7 @@
 						currentQuestion = data.question;
 						questionIndex = data.questionIndex;
 						score = data.score;
-						timeLeft = Math.ceil(data.timeLeftMs / 1000);
+						timeLeft = Math.min(TOTAL_TIME, Math.ceil(data.timeLeftMs / 1000));
 						startTimer();
 					} catch (e) {
 						console.error('Failed to start game:', e);
@@ -103,7 +103,8 @@
 				if (hasEnded) return;
 				lastAnswerCorrect = res.correct;
 				score = res.score;
-				timeLeft = Math.ceil(res.timeLeftMs / 1000);
+				// Don't update timeLeft here to prevent jumping. 
+				// The local timer handles the display, while the server enforces the limit.
 
 				if (res.correct) {
 				audioManager.playSfx('correct');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Countdown now reliably starts at "Go!" (0) and no longer begins prematurely.
  * Local timer no longer jumps when answering; time remaining is kept consistent with the on-screen countdown.

* **Chores**
  * Session expiration window slightly extended to allow a small grace period before a session ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->